### PR TITLE
Fix optimization phase and `s`/`u` strange behaviour in RTD

### DIFF
--- a/modules/view/RTD.red
+++ b/modules/view/RTD.red
@@ -13,7 +13,7 @@ Red [
 context [
 	stack: make block! 10
 	color-stk: make block! 5
-	out: text: s-idx: mark: s: pos: v: none
+	out: text: s-idx: mark: s: pos: v: l: col: none
 
 	;--- Parsing rules ---
 
@@ -42,10 +42,10 @@ context [
 		| color (push-color v) opt [nested (pop-color)]
 		| ahead path!
 		  into [
-			(mark: tail stack) some [					;@@ implement any-single
+			(col: none mark: tail stack) some [					;@@ implement any-single
 				(v: none)
 				s: ['b | 'i | 'u | 's | word! if (tuple? attempt [v: get s/1])]
-				(either v [push-color v][push s/1])
+				(either v [col: yes push-color v][push s/1])
 			]
 		  ]
 		  nested (pop-all mark)
@@ -61,6 +61,7 @@ context [
 	pop-color: has [entry pos][
 		entry: skip tail color-stk -3
 		repend out [as-pair entry/1 tail-idx? - entry/1 entry/3]
+		new-line skip tail out -2 on
 		clear entry
 	]
 
@@ -100,11 +101,11 @@ context [
 
 	pop-all: function [mark [block!]][
 		first?: yes
+		if col [pop-color]
 		while [mark <> tail stack][
 			pop last stack
 			either first? [first?: no][remove skip tail out -2]
 		]
-		if v [pop-color]
 	]
 
 	optimize: function [][								;-- combine same ranges together
@@ -114,7 +115,7 @@ context [
 				any [
 					to range s: skip [to pair! | to end] e: (
 						s: remove s
-						e: next move/part s pos offset? s back e
+						e: skip move/part s pos l: offset? s back e l
 					) :e
 				]
 			]


### PR DESCRIPTION
1) To prevent `underline` or `strike` to be positioned immediately before color-tuple, let's transfer color-setting before other styles in `pop-all`.
```
    pop-all: function [mark [block!]][
        first?: yes 
        if col [pop-color] ; <-- TO HERE
        while [mark <> tail stack][
            pop last stack
            either first? [first?: no][remove skip tail out -2]
        ]
        ;if v [pop-color] FROM HERE --^
    ]
```
2) Notice that `v` is changed to `col` above. That's because `v` is set to `none` on each style in path (line 46 below) and so color was not added if it appeared in earlier places in path. To fix it I introduced new flag `col`, which is set to `none` just once while entering path (line 45), and to `yes` if color is seen in the styles path (line 48).
```
        | ahead path!
          into [
            (col: none mark: tail stack) some [ ; <-- LINE 45
                (v: none) ; <-- LINE 46
                s: ['b | 'i | 'u | 's | word! if (tuple? attempt [v: get s/1])]
                (either v [col: yes push-color v][push s/1]) ; <-- LINE 48
            ]
          ]
          nested (pop-all mark)
```
3) `optimize` func, which is meant to join styles with same indexes, actually worked on first one only and ignored further cases because of miscalculated jump on line 117. My proposal is to replace `next` there with `skip`:
```
; e: next move/part s pos offset? s back e ; CURRENT
e: skip move/part s pos l: offset? s back e l ; PROPOSED
```
In my experiments this works well.

4) A readability problem -- while popping colors `new-line` was not set. I propose to insert one on line 64:
```
    pop-color: has [entry pos][
        entry: skip tail color-stk -3
        repend out [as-pair entry/1 tail-idx? - entry/1 entry/3]
        new-line skip tail out -2 on ; <-- HERE
        clear entry
    ]
```

These fixes correct the second problem mentioned in Gitter post (bugs room 30.12.18) and circumvent the first one without removing the root cause, which is above my head. If ever `strike` or `underline` will appear immediately before color-tuple in data, color is not rendered, e.g. after introducing above fixes, the bug will still affect cases like this:
```
view [rich-text data [s [red "bbb"]]]
;But not this
view [rich-text data [s [red ["bbb"]]]]
```
That's because in first case color is closed in the end of processing only, and is then united to `strike` in optimization phase, but on second case color is closed immediately, and `strike` is united to it.